### PR TITLE
MK and party list running indices

### DIFF
--- a/src/knesset/templates/mks/member_list_with_bars.html
+++ b/src/knesset/templates/mks/member_list_with_bars.html
@@ -7,7 +7,7 @@
 {% block nav-members %}class="selected"{% endblock %}
 {% block subnav %}
         {% for link in friend_pages %}
-            <a style="white-space:nowrap;" href="{{ link.0 }}" {% if link.2 %}class="current"{% endif %}>{{ link.1 }}</a> &bull; 
+            <a style="white-space:nowrap;" href="{{ link.0 }}" {% if link.2 %}class="current"{% endif %}>{{ link.1 }}</a> &bull;
         {% endfor %}
 {% endblock %}
 {% block divcontent %}
@@ -18,6 +18,7 @@
     {% for o in object_list %}
         {% if o.is_current %}
 	    	<tr>
+                <td>{{ forloop.counter }}.</td>
 	    		<td><a class="hashnav item dontwrap" id="detail-{{ o.id }}" href="{% url member-detail o.id %}" title="{{ o.current_party.name }}">{{ o.name }}</a></td>
 	            <td>{{ o.extra|floatformat }}</td>
 	            <td class="column-bar">{% bar o.extra "for" norm_factor %}</td>
@@ -32,6 +33,7 @@
     <table>
     {% for o in past_mks %}
     	<tr>
+            <td>{{ forloop.counter }}.</td>
 	        <td><a class="hashnav item dontwrap" id="detail-{{ o.id }}" href="{% url member-detail o.id %}" title="{{ o.current_party.name }}">{{ o.name }}</a></td>
 	        <td>{{ o.extra|floatformat }}</td>
 	        <td class="column-bar">{% bar o.extra "for" norm_factor %}</td>

--- a/src/knesset/templates/mks/party_list.html
+++ b/src/knesset/templates/mks/party_list.html
@@ -5,7 +5,7 @@
 {% block nav-parties %}class="selected"{% endblock %}
 {% block subnav %}
         {% for link in friend_pages %}
-            <a style="white-space:nowrap;" href="{{ link.0 }}" {% if link.2 %}class="current"{% endif %}>{{ link.1 }}</a> &bull; 
+            <a style="white-space:nowrap;" href="{{ link.0 }}" {% if link.2 %}class="current"{% endif %}>{{ link.1 }}</a> &bull;
         {% endfor %}
 {% endblock %}
 {% block divcontent %}
@@ -14,6 +14,7 @@
         <table>
         {% for o in coalition %}
         	<tr>
+                <td>{{ forloop.counter }}.</td>
 	            <td><a class="hashnav item dontwrap" id="detail-{{ o.id }}" href="{% url party-detail o.id %}">{{ o.name }}</a></td>
 	            <td>{{ o.extra }}</td>
 	            <td class="column-bar">{% bar o.extra "for" norm_factor baseline %}</td>
@@ -28,6 +29,7 @@
         <table>
         {% for o in opposition %}
         	<tr>
+                <td>{{ forloop.counter }}.</td>
 	            <td><a class="hashnav item dontwrap" id="detail-{{ o.id }}" href="{% url party-detail o.id %}">{{ o.name }}</a></td>
 	            <td>{{ o.extra }}</td>
 	            <td class="column-bar">{% bar o.extra "for" norm_factor baseline %}</td>


### PR DESCRIPTION
Hi,

I made a small modification to the MK list and party list templates. It adds a running index (1,2,3...) to each element in the list. 

I needed the change earlier today, because I needed to know Yariv Levin's rank in the list of Meli'a hours. I think it will be useful to other people, also.

Best regards,
Igor
