### PR TITLE
Fix left-to-right display of trackback link

### DIFF
--- a/src/knesset/templates/mks/member_detail.html
+++ b/src/knesset/templates/mks/member_detail.html
@@ -396,7 +396,7 @@
                 <p>{% trans "This entry has not been pinged." %}</p>
             {% endif %}
         {% endwith %}
-        <p>{% trans "TrackBack:" %} <span style="direction:ltr">{% absurl member-trackback object_id=object.id %}</span> </p>
+        <p>{% trans "TrackBack:" %} <span style="direction:ltr; unicode-bidi:embed;">{% absurl member-trackback object_id=object.id %}</span> </p>
     	</div>
 	{% endif %} 
 	<br />


### PR DESCRIPTION
Trackbacks used to (visually) appear as:

```
/http://oknesset.org/trackback/member/1
```

Adding `unicode-bidi: embed` makes them appear correctly as

```
http://oknesset.org/trackback/member/1/
```
