### PR TITLE
buildout.cfg tweaks, and create an envfile

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,7 +3,7 @@ unzip = true
 prefer-final = true
 versions = versions
 extensions = buildout.dumppickedversions
-parts = python django console_scripts activity_stream tagging planet annotatetext pydev mailer avatar hitcount backlinks pyth
+parts = python django console_scripts activity_stream tagging planet annotatetext pydev mailer avatar hitcount backlinks pyth envfile
 develop = .
 eggs = 
     Open-Knesset


### PR DESCRIPTION
The envfile can be sourced in a shell prior to running vim, etc.
