### PR TITLE
Template-tag for bill_full_name

### DIFF
--- a/src/knesset/laws/templatetags/bills_extra.py
+++ b/src/knesset/laws/templatetags/bills_extra.py
@@ -1,0 +1,7 @@
+from django import template
+
+register = template.Library()
+
+@register.inclusion_tag('laws/bill_full_name.html')
+def bill_full_name(bill):
+    return { 'bill': bill }

--- a/src/knesset/laws/views.py
+++ b/src/knesset/laws/views.py
@@ -168,13 +168,8 @@ class BillDetailView (DetailView):
     def get_context_data(self, *args, **kwargs):
         context = super(BillDetailView, self).get_context_data(*args, **kwargs)
         bill = context['object']
-        try:
-            context['title'] = "%s,%s" % (bill.law.title, bill.title)
-        except AttributeError:
-            context['title'] = bill.title
         if bill.popular_name:
             context["keywords"] = bill.popular_name
-            context['title'] = "%s (%s)" % (context["title"], bill.popular_name)
         if self.request.user.is_authenticated():
             p = self.request.user.get_profile()
             context['watched'] = bill in p.bills

--- a/src/knesset/templates/laws/bill_detail.html
+++ b/src/knesset/templates/laws/bill_detail.html
@@ -1,6 +1,7 @@
 {% extends "site_base.html" %}
 {% load i18n %}
 {% load laws_extra %}
+{% load bills_extra %}
 {% load tagging_tags %}
 {% load mks %}
 {% block extrahead %}
@@ -8,9 +9,9 @@
 <script type="text/javascript" src="{{MEDIA_URL}}js/tagging.js"></script>
 <script type="text/javascript" src="{{MEDIA_URL}}js/jquery.autocomplete.js"></script>
 {% endblock %}
-{% block extratitle %}{{ title }}{% endblock %}
-{% block keywords %}{{ title }},{{ keywords }}{% endblock %}
-{% block description %}{{ title }} - {% trans 'Open Knesset - Opening the Knesset to the public' %}{% endblock %}
+{% block extratitle %}{% bill_full_name object %}{% endblock %}
+{% block keywords %}{% bill_full_name object %},{{ keywords }}{% endblock %}
+{% block description %}{% bill_full_name object %} - {% trans 'Open Knesset - Opening the Knesset to the public' %}{% endblock %}
 {% block nav-laws %}class="selected"{% endblock %}
 {% block messages %}
 <span id="message_login">
@@ -24,7 +25,7 @@
     <ul class="actions">
         <li><span id="watch" class="awesome-button medium"></span></li>
     </ul>
-    <h1>{{ title }}</h1>
+    <h1>{% bill_full_name object %}</h1>
     {% trans 'stage' %}: {% trans object.get_stage_display %}<br>
     {% trans 'stage date' %}: {{ object.stage_date }}<br>
     {% for proposer in object.proposers.all %}

--- a/src/knesset/templates/laws/bill_full_name.html
+++ b/src/knesset/templates/laws/bill_full_name.html
@@ -1,0 +1,1 @@
+{% if bill.law %}{{ bill.law.title }}, {% endif %}{{ bill.title }} {% if bill.popular_name%} ({{bill.popular_name}}) {% endif %}

--- a/src/knesset/templates/laws/bill_list.html
+++ b/src/knesset/templates/laws/bill_list.html
@@ -1,6 +1,7 @@
 {% extends "site_base.html" %}
 {% load i18n %}
 {% load laws_extra %}
+{% load bills_extra %}
 {% block extratitle %}{{ title }}{% endblock %}
 {% block keywords %}{{ title }}{% endblock %}
 {% block description %}{{ title }} - {% trans 'Open Knesset - Opening the Knesset to the public' %}{% endblock %}
@@ -23,7 +24,7 @@
         {% for o in object_list %}
             <div class="item {% cycle "normal" "alt" %}">
                 <div class="date-item">{{ o.stage_date|date:"d/m"}}<span>{{o.stage_date|date:"Y"}}</span></div>
-                <a id="detail-{{ o.id }}" href="{% url bill-detail o.id %}">{{ o.law.title }} {{ o.title }} {% if o.popular_name%} ({{o.popular_name}}) {% endif %}</a>
+                <a id="detail-{{ o.id }}" href="{% url bill-detail o.id %}">{% bill_full_name o %}</a>
                 <div class="item-metadata">
                     <span class="stage stage_{{o.stage|slugify}}">{% trans o.get_stage_display %}</span>
                     <span class="item-tags">

--- a/src/knesset/templates/laws/bill_list_by_tag.html
+++ b/src/knesset/templates/laws/bill_list_by_tag.html
@@ -1,6 +1,7 @@
 {% extends "site_base.html" %}
 {% load i18n %}
 {% load laws_extra %}
+{% load bills_extra %}
 {% block extratitle %}{{ title }}{% endblock %}
 {% block keywords %}{{ title }}{% endblock %}
 {% block description %}{{ title }} - {% trans 'Open Knesset - Opening the Knesset to the public' %}{% endblock %}
@@ -16,8 +17,19 @@
     <a href="{% url bill-tags-cloud %}{% if member %}?member={{member.id}}{% endif %}">{% trans 'Choose another tag' %}</a><br>
 	<div class="item-list">
         {% for o in object_list %}
-            <div class="item">
-                <a id="detail-{{ o.id }}" href="{% url bill-detail o.id %}">{{ o.law.title }} {{ o.title }}</a> {% trans o.get_stage_display %} ({{ o.stage_date }})<br/>
+            <div class="item {% cycle "normal" "alt" %}">
+                <div class="date-item">{{ o.stage_date|date:"d/m"}}<span>{{o.stage_date|date:"Y"}}</span></div>
+                <a id="detail-{{ o.id }}" href="{% url bill-detail o.id %}">{% bill_full_name o %}</a>
+                <div class="item-metadata">
+                    <span class="stage stage_{{o.stage|slugify}}">{% trans o.get_stage_display %}</span>
+                    <span class="item-tags">
+                    {% trans "Tags" %}:
+                    {% for tag in o.tags %}
+                        {% if not forloop.first %} | {% endif %}
+                        <a href="{% url bill-tag tag=tag %}">{{ tag.name }}</a>
+                        {% endfor %}
+                    </span>
+                </div>
             </div>
         {% empty %}
             {% trans "No results found" %}

--- a/src/knesset/templates/laws/vote_detail.html
+++ b/src/knesset/templates/laws/vote_detail.html
@@ -1,6 +1,7 @@
 {% extends "two_cols.html" %}
 {% load i18n %}
 {% load tagging_tags %}
+{% load bills_extra %}
 {% load links %}
 {% load mks %}
 {% load agendas %}
@@ -125,7 +126,7 @@
         <h3>{% trans 'Bill' %}</h3>
         <ul class="items">
         {% for bill in bills %}
-            <li><a href={% url bill-detail bill.id %}>{{ bill }}</a></li>
+            <li><a href={% url bill-detail bill.id %}>{% bill_full_name bill %}</a></li>
         {% empty %}
             {% trans 'No bill is associated with this vote' %}
         {% endfor %}


### PR DESCRIPTION
Add template-tag for bill_full_name - which include the law name (if exists), bill name and popular name (if exists). change some templates to use this tag, and remoe duplicated logic. In addition, copy the new look of bill list to bill list by tag.

Futures changes on "bill full name" will be done in one place.

(i didn't change bill api, because i am afraid that it would break something, but IMHO we should change it)
