### PR TITLE
Added tastypie-swagger module, initial swagger support

### DIFF
--- a/apis/urls.py
+++ b/apis/urls.py
@@ -50,4 +50,6 @@ urlpatterns = patterns('',
       url(r'^event/icalendar/$', 'events.views.icalendar', name='event-icalendar'),
       url(r'^event/icalendar/(?P<summary_length>\d+)/$', 'events.views.icalendar', name='event-icalendar'),
       (r'^', include(v2_api.urls)),
+      url(r'^v2/doc/', include('tastypie_swagger.urls', namespace='v2api_tastypie_swagger'),
+          kwargs={"tastypie_api_module":"apis.resources.v2_api", "namespace":"v2api_tastypie_swagger", "version": "2.0"})
       )

--- a/knesset/settings.py
+++ b/knesset/settings.py
@@ -126,6 +126,7 @@ INSTALLED_APPS = (
     'django.contrib.flatpages',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'tastypie_swagger',
     'piston',                       # friends apps
     'debug_toolbar',
     'tagging',
@@ -293,6 +294,8 @@ DEVSERVER_DEFAULT_PORT = 8000
 # TODO: Look into switching to django-allauth instead and using the session
 # serializer.
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+
+TASTYPIE_SWAGGER_API_MODULE = 'apis.resources.v2_api'
 
 # if you add a local_settings.py file, it will override settings here
 # but please, don't commit it to git.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ South==0.8.4
 django-extensions==1.2.5
 django-pagination==1.0.7
 django-tagging==0.3.1
+django-tastypie-swagger==0.1.2
 BeautifulSoup
 vobject
 feedparser


### PR DESCRIPTION
branch rebased on ofri:master.

Swagger is accessible under the `/api/v2/doc/` endpoint. Just in case, I would like to have someone familiar with the API go over the swagger generated docs to see if anything is missing, if no "special" methods were used then the swagger should be complete.
